### PR TITLE
docs: `notmuch address` command fixes

### DIFF
--- a/docs/source/configuration/contacts_completion.rst
+++ b/docs/source/configuration/contacts_completion.rst
@@ -64,7 +64,7 @@ Both respect the `ignorecase` option which defaults to `True` and results in cas
 
         .. code-block:: ini
 
-           command = 'notmuch address --format=json --output=recipients date:1Y.. AND from:my@address.org'
+           command = 'notmuch address --format=json date:1Y.. AND from:'
            regexp = '\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?'
            shellcommand_external_filtering = False
 


### PR DESCRIPTION
- Removed recipients search, default senders search is much faster
- Removed "my@address.org" from command, address seems to be added at the end of line automatically